### PR TITLE
Adds Deploy to Heroku Button in Readme

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec rackup -p $PORT

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ This service works great with [Rollout-Dashboard](https://github.com/fiverr/roll
 # FAQ
 
 # How to set redis configuration?
-Edit `./config/redis.yml`
+
+Add the `REDIS_URL` environment variable. On *nix systems you can do the following:
+`export REDIS_URL="redis://username:password@redis.url:port"`
 
 ## How to start the service?
 run `bundle exec rackup -p :port`

--- a/README.md
+++ b/README.md
@@ -23,34 +23,34 @@ This service works great with [Rollout-Dashboard](https://github.com/fiverr/roll
 
 # FAQ
 
-# Configuring through the environment
+### Configuring through the environment
 
-## How to configure redis?
+#### How to configure redis?
 
 Add the `REDIS_URL` environment variable. On *nix systems you can do the following:
 `export REDIS_URL="redis://username:password@redis.url:port"`
 
-## How to limit google authentication to a single domain?
+#### How to limit google authentication to a single domain?
 
 Add the `GOOGLE_OAUTH_ALLOWED_DOMAIN` environment variable. On *nix systems you can do the following:
 `export GOOGLE_OAUTH_ALLOWED_DOMAIN="fiverr.com"`
 
-# Configuring through yaml files
+### Configuring through yaml files
 
-## How to configure redis?
+#### How to configure redis?
 
 Edit `./config/redis.yml`
 
-## How to limit google authentication to a single domain?
+#### How to limit google authentication to a single domain?
 
 Edit `./config/authentication.yml`
 
-# Running the service
+### Running the service
 
-## Heroku
+#### Heroku
 
 The Procfile will manage this for you.
 
-## Elsewhere
+#### Elsewhere
 
 run `bundle exec rackup -p :port`

--- a/README.md
+++ b/README.md
@@ -28,5 +28,10 @@ This service works great with [Rollout-Dashboard](https://github.com/fiverr/roll
 Add the `REDIS_URL` environment variable. On *nix systems you can do the following:
 `export REDIS_URL="redis://username:password@redis.url:port"`
 
+# How to limit google authentication to a single domain?
+
+Add the `GOOGLE_OAUTH_ALLOWED_DOMAIN` environment variable. On *nix systems you can do the following:
+`export GOOGLE_OAUTH_ALLOWED_DOMAIN="fiverr.com"`
+
 ## How to start the service?
 run `bundle exec rackup -p :port`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 
 This service expose RESTfull endpoints that allows you to perform CRUD operation on [rollout](https://github.com/fetlife/rollout) gem.
 
-This service works great with [Rollout-Dashboard](https://github.com/fiverr/rollout_dashboard) - a beautiful user interface for rollout gem) 
+This service works great with [Rollout-Dashboard](https://github.com/fiverr/rollout_dashboard) - a beautiful user interface for rollout gem)
+
+## Deploy
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
 ## End-Points Documentation:
 
@@ -17,11 +21,10 @@ This service works great with [Rollout-Dashboard](https://github.com/fiverr/roll
 | Partially update existing feature  | PATCH /api/v1/features/:feature_name  |
 | Delete a feature  | DELETE /api/v1/features/:feature_name  |
 
-
 # FAQ
 
 # How to set redis configuration?
 Edit `./config/redis.yml`
 
-## How to start the service? 
+## How to start the service?
 run `bundle exec rackup -p :port`

--- a/README.md
+++ b/README.md
@@ -23,15 +23,34 @@ This service works great with [Rollout-Dashboard](https://github.com/fiverr/roll
 
 # FAQ
 
-# How to set redis configuration?
+# Configuring through the environment
+
+## How to configure redis?
 
 Add the `REDIS_URL` environment variable. On *nix systems you can do the following:
 `export REDIS_URL="redis://username:password@redis.url:port"`
 
-# How to limit google authentication to a single domain?
+## How to limit google authentication to a single domain?
 
 Add the `GOOGLE_OAUTH_ALLOWED_DOMAIN` environment variable. On *nix systems you can do the following:
 `export GOOGLE_OAUTH_ALLOWED_DOMAIN="fiverr.com"`
 
-## How to start the service?
+# Configuring through yaml files
+
+## How to configure redis?
+
+Edit `./config/redis.yml`
+
+## How to limit google authentication to a single domain?
+
+Edit `./config/authentication.yml`
+
+# Running the service
+
+## Heroku
+
+The Procfile will manage this for you.
+
+## Elsewhere
+
 run `bundle exec rackup -p :port`

--- a/app.json
+++ b/app.json
@@ -1,0 +1,19 @@
+{
+    "name": "Rollout Service",
+    "description": "A Grape service that expose rollout gem via RESTful endpoints",
+    "repository": "https://github.com/fiverr/rollout_service",
+    "keywords": [
+        "feature flag",
+        "rollout",
+        "rollout api"
+    ],
+    "addons": [
+        "heroku-redis:hobby-dev"
+    ],
+    "env": {
+        "GOOGLE_OAUTH_ALLOWED_DOMAIN": {
+            "description": "The domain to limit google authentication with.",
+            "value": "@fiverr.com"
+        }
+    }
+}

--- a/app.json
+++ b/app.json
@@ -13,7 +13,7 @@
     "env": {
         "GOOGLE_OAUTH_ALLOWED_DOMAIN": {
             "description": "The domain to limit google authentication with.",
-            "value": "@fiverr.com"
+            "value": "fiverr.com"
         }
     }
 }

--- a/config/authentication.yml
+++ b/config/authentication.yml
@@ -1,0 +1,2 @@
+development:
+   :google_oauth_allowed_domain: ''

--- a/config/authentication.yml
+++ b/config/authentication.yml
@@ -1,2 +1,0 @@
-development:
-   :google_oauth_allowed_domain: ''

--- a/config/authentication.yml
+++ b/config/authentication.yml
@@ -1,2 +1,2 @@
 development:
-   :google_oauth_allowed_domain: ''
+  :google_oauth_allowed_domain: ''

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,0 +1,3 @@
+development:
+  host: 127.0.0.1
+  port: 6379

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,3 +1,0 @@
-development:
-  host: 127.0.0.1
-  port: 6379

--- a/syslib/globals.rb
+++ b/syslib/globals.rb
@@ -6,8 +6,7 @@ module Globals
   end
 
   def redis
-    config =  YAML.load(File.read('./config/redis.yml'))[$env]
-    $redis = Redis.new(config)
+    $redis = Redis.new(url: ENV['REDIS_URL'])
   end
 
   def rollout
@@ -15,8 +14,7 @@ module Globals
   end
 
   def authentication
-    config =  YAML.load(File.read('./config/authentication.yml'))[$env]
-    $google_oauth_allowed_domain = config[:google_oauth_allowed_domain]
+    $google_oauth_allowed_domain = ENV['GOOGLE_OAUTH_ALLOWED_DOMAIN']
   end
 
   def setup

--- a/syslib/globals.rb
+++ b/syslib/globals.rb
@@ -6,7 +6,7 @@ module Globals
   end
 
   def redis
-    if ENV['REDIS_URL'].is_nil?
+    if ENV['REDIS_URL'].nil?
       config = YAML.load(File.read('./config/redis.yml'))[$env]
       $redis = Redis.new(config)
     else

--- a/syslib/globals.rb
+++ b/syslib/globals.rb
@@ -6,8 +6,12 @@ module Globals
   end
 
   def redis
-    if
-    $redis = Redis.new(url: ENV['REDIS_URL'])
+    if ENV['REDIS_URL'].is_nil?
+      config = YAML.load(File.read('./config/redis.yml'))[$env]
+      $redis = Redis.new(config)
+    else
+      $redis = Redis.new(url: ENV['REDIS_URL'])
+    end
   end
 
   def rollout

--- a/syslib/globals.rb
+++ b/syslib/globals.rb
@@ -6,6 +6,7 @@ module Globals
   end
 
   def redis
+    if
     $redis = Redis.new(url: ENV['REDIS_URL'])
   end
 
@@ -14,7 +15,10 @@ module Globals
   end
 
   def authentication
-    $google_oauth_allowed_domain = ENV['GOOGLE_OAUTH_ALLOWED_DOMAIN']
+    config = YAML.load(File.read('./config/authentication.yml'))[$env]
+    $google_oauth_allowed_domain =
+      ENV['GOOGLE_OAUTH_ALLOWED_DOMAIN'] ||
+      config[:google_oauth_allowed_domain]
   end
 
   def setup


### PR DESCRIPTION
Moved the configurations for redis and google authentication to the environment vs. yml files. This along with the introduction of the app.js and the Procfile allow you now deploy to heroku in a single click.

Let me know what you think.